### PR TITLE
Add to all-packages.nix and add SystemConfiguration

### DIFF
--- a/pkgs/misc/nostr-rs-relay/default.nix
+++ b/pkgs/misc/nostr-rs-relay/default.nix
@@ -8,7 +8,7 @@
   pkg-config,
   libiconv,
   darwin,
-  protobuf
+  protobuf,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "nostr-rs-relay";
@@ -31,6 +31,7 @@ rustPlatform.buildRustPackage rec {
     ++ lib.optional stdenv.isDarwin [
       libiconv
       darwin.apple_sdk.frameworks.Security
+      darwin.apple_sdk.frameworks.SystemConfiguration
     ]
     ++ lib.optional stdenv.isLinux [];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5433,6 +5433,8 @@ with pkgs;
 
   nixpkgs-pytools = with python3.pkgs; toPythonApplication nixpkgs-pytools;
 
+  nostr-rs-relay = callPackage ../misc/nostr-rs-relay { };
+
   notemap = callPackage ../tools/networking/notemap { };
 
   noteshrink = callPackage ../tools/misc/noteshrink { };


### PR DESCRIPTION
This got me building on Mac!
```
> ./result/bin/nostr-rs-relay --help                       
A nostr relay written in Rust

Usage: nostr-rs-relay [OPTIONS]

Options:
  -d, --db <DB>          Use the <directory> as the location of the database
  -c, --config <CONFIG>  Use the <file name> as the location of the config file
  -h, --help             Print help
  -V, --version          Print version
```